### PR TITLE
fix(vimeo): load thumbnail using Vimeo API

### DIFF
--- a/src/components/LazyVimeo.vue
+++ b/src/components/LazyVimeo.vue
@@ -76,11 +76,6 @@ import VideoWrapper from "./common/Wrapper";
 export default {
 name: "LazyVimeo",
   mixins: [commonMixin, vimeoMixin],
-  data() {
-    return {
-      videoID: null
-    }
-  },
   props: {
     src: {
       type: String,
@@ -133,6 +128,9 @@ name: "LazyVimeo",
 
   },
   computed: {
+    videoID: function () {
+      return this.getVimeoID(this.src)
+    },
     aspectRatioValue: function () {
       return this.calcAspect(this.aspectRatio)
     },

--- a/src/mixins/commonMixin.js
+++ b/src/mixins/commonMixin.js
@@ -17,14 +17,20 @@ export default {
       const self = this
       let url = ''
 
-      url = type === 'youtube' ? `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${this.videoID}&format=json` : `https://vimeo.com/api/oembed.json?url=${this.src}`
+      url = type === 'youtube' ? `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${this.videoID}&format=json` : `https://vimeo.com/api/v2/video/${this.videoID}.json`
       axios.get(url)
         .then(function (response) {
+
+          console.log(response.data);
           // handle success
-          self.videoInfo = response.data
-          if (type === 'vimeo') {
-            self.videoID = response.data.video_id
+          if(type === 'youtube') {
+            self.videoInfo = response.data
           }
+          
+          if (type === 'vimeo') {
+            self.videoInfo = response.data[0]
+          }
+
           self.isVideoFound = true
         })
         .catch(function () {
@@ -32,7 +38,7 @@ export default {
           self.videoInfo = null
           self.isVideoFound = false
         })
-        .then(function () {
+        .finally(function () {
           // always executed
           self.fetchingInfo = false
 

--- a/src/mixins/commonMixin.js
+++ b/src/mixins/commonMixin.js
@@ -20,13 +20,11 @@ export default {
       url = type === 'youtube' ? `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${this.videoID}&format=json` : `https://vimeo.com/api/v2/video/${this.videoID}.json`
       axios.get(url)
         .then(function (response) {
-
-          console.log(response.data);
           // handle success
           if(type === 'youtube') {
             self.videoInfo = response.data
           }
-          
+
           if (type === 'vimeo') {
             self.videoInfo = response.data[0]
           }

--- a/src/mixins/vimeoMixin.js
+++ b/src/mixins/vimeoMixin.js
@@ -1,7 +1,10 @@
-const axios = require('axios').default
+// const axios = require('axios').default
 
 export default {
     methods: {
+        getVimeoID (url) {
+            return new URL(url).pathname.split('/').pop();
+        },
         playVideo() {
             if(!this.isPostMessageSupported) {
                 return
@@ -36,10 +39,7 @@ export default {
             if(!video_id) return false;
             
             const _quality = ['small', 'medium', 'large'].includes(quality) ? quality: 'medium';
-
-            return axios
-                .get(`https://vimeo.com/api/v2/video/${video_id}.json`)
-                .then(({data}) => data[`thumbnail_${_quality}`]);
+            return this.videoInfo['thumbnail_'+_quality];
         }
     }
 };

--- a/src/mixins/vimeoMixin.js
+++ b/src/mixins/vimeoMixin.js
@@ -38,7 +38,7 @@ export default {
             const _quality = ['small', 'medium', 'large'].includes(quality) ? quality: 'medium';
 
             return axios
-                .get(`http://vimeo.com/api/v2/video/${video_id}.json`)
+                .get(`https://vimeo.com/api/v2/video/${video_id}.json`)
                 .then(({data}) => data[`thumbnail_${_quality}`]);
         }
     }

--- a/src/mixins/vimeoMixin.js
+++ b/src/mixins/vimeoMixin.js
@@ -39,7 +39,7 @@ export default {
             if(!video_id) return false;
             
             const _quality = ['small', 'medium', 'large'].includes(quality) ? quality: 'medium';
-            return this.videoInfo['thumbnail_'+_quality];
+            return this.videoInfo[`thumbnail_${_quality}`];
         }
     }
 };

--- a/src/mixins/vimeoMixin.js
+++ b/src/mixins/vimeoMixin.js
@@ -1,3 +1,5 @@
+const axios = require('axios').default
+
 export default {
     methods: {
         playVideo() {
@@ -31,35 +33,14 @@ export default {
         },
 
         getVimeoThumbnail(video_id, quality){
-            let thumbnail;
-
-            if(video_id){
-                if(typeof quality == "undefined"){
-                    quality = 'high';
-                }
-
-                let quality_key = '960x540';
-                if(quality === 'default'){
-                    quality_key = '200x150';
-                }
-                else if(quality === 'medium'){
-                    quality_key = '295x166';
-                }
-                else if(quality === 'high'){
-                    quality_key = '640x360';
-                }
-                else if (quality === 'standard') {
-                    quality_key = '960x540';
-                }
-                else if (quality === 'maxres') {
-                    quality_key = '1280x720';
-                }
-
-                thumbnail = "https://i.vimeocdn.com/video/"+video_id+"_"+quality_key+".jpg";
-                return thumbnail;
+            if(!video_id) return false;
+            if(!['small', 'medium', 'large'].includes(quality)) {
+                quality = 'medium';
             }
 
-            return false;
+            return axios
+                .get(`http://vimeo.com/api/v2/video/${video_id}.json`)
+                .then(({data}) => data[`thumbnail_${quality}`]);
         }
     }
 };

--- a/src/mixins/vimeoMixin.js
+++ b/src/mixins/vimeoMixin.js
@@ -34,13 +34,12 @@ export default {
 
         getVimeoThumbnail(video_id, quality){
             if(!video_id) return false;
-            if(!['small', 'medium', 'large'].includes(quality)) {
-                quality = 'medium';
-            }
+            
+            const _quality = ['small', 'medium', 'large'].includes(quality) ? quality: 'medium';
 
             return axios
                 .get(`http://vimeo.com/api/v2/video/${video_id}.json`)
-                .then(({data}) => data[`thumbnail_${quality}`]);
+                .then(({data}) => data[`thumbnail_${_quality}`]);
         }
     }
 };

--- a/src/mixins/youtubeMixin.js
+++ b/src/mixins/youtubeMixin.js
@@ -56,7 +56,7 @@ export default {
           quality_key = 'maxresdefault'
         }
 
-        thumbnail = 'http://img.youtube.com/vi/' + video_id + '/' + quality_key + '.jpg'
+        thumbnail = 'https://img.youtube.com/vi/' + video_id + '/' + quality_key + '.jpg'
         return thumbnail
       }
 

--- a/src/mixins/youtubeMixin.js
+++ b/src/mixins/youtubeMixin.js
@@ -36,8 +36,6 @@ export default {
       }
     },
     getYoutubeThumbnail (video_id, quality) {
-      let thumbnail
-
       if (video_id) {
         if (typeof quality === 'undefined') {
           quality = 'high'
@@ -56,8 +54,7 @@ export default {
           quality_key = 'maxresdefault'
         }
 
-        thumbnail = 'https://img.youtube.com/vi/' + video_id + '/' + quality_key + '.jpg'
-        return thumbnail
+        return `https://img.youtube.com/vi/${video_id}/${quality_key}.jpg`;
       }
 
       return false


### PR DESCRIPTION
- Fix the thumbnail loading for Vimeo
- Fix #16 
- Fix #13 

``getVimeoThumbnail`` use now the Vimeo API to fetch metadata about the video, allowing it to find the thumbnail URL for the following sizes: ``small``, ``medium``, ``large``. I saw that Axios was already a dependency so I used it in my code